### PR TITLE
add statsd-ruby gem as normal dependency

### DIFF
--- a/fluent-plugin-statsd.gemspec
+++ b/fluent-plugin-statsd.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency "fluentd", ">= 0.10.8"
+  gem.add_dependency "statsd-ruby", ">=1.2.1"
 
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "statsd-ruby", ">=1.2.1"


### PR DESCRIPTION
adding the statsd gem as a normal dependency makes the gem install build it before this gem is installed and prevents errors like
```
`require': cannot load such file -- statsd-ruby (LoadError)
```