### PR TITLE
Migrate to use v1 API

### DIFF
--- a/fluent-plugin-statsd.gemspec
+++ b/fluent-plugin-statsd.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency "fluentd", ">= 0.10.8"
+  gem.add_dependency "fluentd", [">= 0.14.15", "< 2"]
 
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.2.0"

--- a/test/plugin/out_statsd.rb
+++ b/test/plugin/out_statsd.rb
@@ -1,15 +1,19 @@
 require 'fluent/plugin/out_statsd'
 require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/output'
 require 'statsd-ruby'
 
 class StatsdOutputTest < Test::Unit::TestCase
+  include Fluent::Test::Helpers
+
   def setup
     super
     Fluent::Test.setup
-    @now = Time.now
+    @now = event_time
   end
 
-  def treedown
+  def teardown
   end
 
   CONFIG = %[
@@ -17,17 +21,17 @@ class StatsdOutputTest < Test::Unit::TestCase
   ]
 
   def create_driver(conf = CONFIG)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::StatsdOutput) {
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::StatsdOutput) {
     }.configure(conf)
   end
 
   def test_write
     d = create_driver
-    time = Time.at(@now.to_i).utc
-    d.emit({ :stastd_type => 'timing', :statsd_key => 'test.statsd.t', :statsd_timing => 100 }, time)
-    d.emit({ :stastd_type => 'guage', :statsd_key => 'test.statsd.g', :statsd_gauge => 102 }, time)
-    d.emit({ :stastd_type => 'increment', :statsd_key => 'test.statsd.i'}, time)
-
-    d.run
+    time = @now
+    d.run(default_tag: 'test') do
+      d.feed(time, { :stastd_type => 'timing', :statsd_key => 'test.statsd.t', :statsd_timing => 100 })
+      d.feed(time, { :stastd_type => 'guage', :statsd_key => 'test.statsd.g', :statsd_gauge => 102 })
+      d.feed(time, { :stastd_type => 'increment', :statsd_key => 'test.statsd.i'})
+    end
   end
 end


### PR DESCRIPTION
The brand new v1 API can handle EventTime in plugin, working with multi
workers, and provides elastic testing APIs.