### PR TITLE
Add Sampling rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ $ fluent-gem install fluent-plugin-statsd
   type statsd
   host localhost # optional
   port 8125# optional
+  sample_rate 0.9 # optional
 </match>
 ```
 
@@ -22,36 +23,42 @@ $ fluent-gem install fluent-plugin-statsd
 fluent_logger.post('statsd',
   :statsd_type => 'timing',
   :statsd_key => 'org.foo.timing',
-  :statsd_timing => 0.234
+  :statsd_timing => 0.234,
+  :statsd_rate => 0.8 # Optional
 )
 
 fluent_logger.post('statsd',
   :statsd_type => 'gauge',
   :statsd_gauge => 10,
-  :statsd_key => 'org.foo.gauge'
+  :statsd_key => 'org.foo.gauge',
+  :statsd_rate => 0.2 # Optional
 )
 
 fluent_logger.post('statsd',
   :statsd_type => 'count',
   :statsd_gauge => 10,
-  :statsd_key => 'org.foo.gauge'
+  :statsd_key => 'org.foo.gauge',
+  :statsd_rate => 1 # Optional
 )
 
 fluent_logger.post('statsd',
   :statsd_type => 'set',
   :statsd_gauge => 10,
-  :statsd_key => 'org.foo.gauge'
+  :statsd_key => 'org.foo.gauge',
+  :statsd_rate => 0.3 # Optional
 )
 
 fluent_logger.post('statsd',
   :statsd_type => 'increment',
-  :statsd_key => 'org.foo.counter'
+  :statsd_key => 'org.foo.counter',
+  :statsd_rate => 0.1 # Optional
 )
 
 
 fluent_logger.post('statsd',
   :statsd_type => 'decrement',
-  :statsd_key => 'org.foo.counter'
+  :statsd_key => 'org.foo.counter',
+  :statsd_rate => 0.6 # Optional
 )
 ```
 
@@ -77,6 +84,7 @@ worked with record_reformer to transform access log request_time into statsd
   statsd_key ${"url"+request_uri.gsub(/((\/[^\/]+){2}).*/, '\1').gsub(/([^\?]*)\?.*/,'\1').gsub(/[0-9]+/, "NN").gsub(/\//, ".");}
   statsd_timing ${request_time}
   statsd_type ${"timing"}
+  statsd_rate 0.1
 </match>
 ```
 

--- a/lib/fluent/plugin/out_statsd.rb
+++ b/lib/fluent/plugin/out_statsd.rb
@@ -6,6 +6,7 @@ module Fluent
     Fluent::Plugin.register_output('statsd', self)
 
     config_param :flush_interval, :time, :default => 1
+    config_param :sample_rate, :float, :default => 1
     config_param :host, :string, :default => 'localhost'
     config_param :port, :string, :default => '8125'
 
@@ -34,20 +35,22 @@ module Fluent
 
     def write(chunk)
       chunk.msgpack_each {|record|
+        record['statsd_rate'] = sample_rate unless record.key? 'statsd_rate'
+
         if statsd_type = record['statsd_type']
           case statsd_type
           when 'timing'
-            @statsd.timing record['statsd_key'], record['statsd_timing'].to_f
+            @statsd.timing record['statsd_key'], record['statsd_timing'].to_f, sample_rate: record['statsd_rate']
           when 'gauge'
-            @statsd.gauge record['statsd_key'], record['statsd_gauge'].to_f
+            @statsd.gauge record['statsd_key'], record['statsd_gauge'].to_f, sample_rate: record['statsd_rate']
           when 'count'
-            @statsd.count record['statsd_key'], record['statsd_count'].to_f
+            @statsd.count record['statsd_key'], record['statsd_count'].to_f, sample_rate: record['statsd_rate']
           when 'set'
-            @statsd.set record['statsd_key'], record['statsd_set']
+            @statsd.set record['statsd_key'], record['statsd_set'], sample_rate: record['statsd_rate']
           when 'increment'
-            @statsd.increment record['statsd_key']
+            @statsd.increment record['statsd_key'], sample_rate: record['statsd_rate']
           when 'decrement'
-            @statsd.decrement record['statsd_key']
+            @statsd.decrement record['statsd_key'], sample_rate: record['statsd_rate']
           end
         end
       }


### PR DESCRIPTION
Adds a sampling rate configuration value and per-record value.  Helpful if you're getting too many hits to your metric and want to keep statsd/graphite happy.